### PR TITLE
“Commercial” => “proprietary” licenses

### DIFF
--- a/butter-cms.json
+++ b/butter-cms.json
@@ -2,7 +2,7 @@
     "Timestamp": "2018-08-01T13:38:27.000Z",
     "Name": "ButterCMS",
     "Version": "06-2019",
-    "License": "Commercial",
+    "License": "Proprietary",
     "Inception": "05-2015",
     "Category": "Essential",
     "Open Source": "No",

--- a/cloudcms.json
+++ b/cloudcms.json
@@ -2,7 +2,7 @@
     "Timestamp": "2018-07-28T13:05:54.590Z",
     "Name": "Cloud CMS",
     "Version": "3.2.0",
-    "License": "Commercial",
+    "License": "Proprietary",
     "Inception": "05-2009",
     "Category": "Professional - Enterprise",
     "Open Source": "No",

--- a/comfortable-io.json
+++ b/comfortable-io.json
@@ -2,7 +2,7 @@
     "Timestamp": "2018-07-29T10:13:46.256Z",
     "Name": "comfortable.io",
     "Version": "08-2018",
-    "License": "Commercial",
+    "License": "Proprietary",
     "Inception": "08-2014",
     "Category": "Essential - Professional",
     "Open Source": "No",

--- a/contentful.json
+++ b/contentful.json
@@ -2,7 +2,7 @@
     "Timestamp": "2018-07-28T17:34:41.227Z",
     "Name": "Contentful",
     "Version": "08-2018",
-    "License": "Commercial",
+    "License": "Proprietary",
     "Inception": "07-2010",
     "Category": "Essential - Professional",
     "Open Source": "No",

--- a/cosmicjs.json
+++ b/cosmicjs.json
@@ -2,7 +2,7 @@
     "Timestamp": "2018-07-29T08:58:50.050Z",
     "Name": "Cosmic JS",
     "Version": "08-2018",
-    "License": "Commercial",
+    "License": "Proprietary",
     "Inception": "05-2014",
     "Category": "Professional",
     "Open Source": "No",

--- a/graphcms.json
+++ b/graphcms.json
@@ -2,7 +2,7 @@
   "Timestamp": "2018-07-28T16:20:32.551Z",
   "Name": "GraphCMS",
   "Version": "08-2018",
-  "License": "Commercial",
+  "License": "Proprietary",
   "Inception": "06-2016",
   "Category": "Essential - Professional",
   "Open Source": "No",

--- a/kentico-cloud.json
+++ b/kentico-cloud.json
@@ -2,7 +2,7 @@
     "Timestamp": "2018-07-30T08:07:39.033Z",
     "Name": "Kentico Cloud",
     "Version": "08-2018",
-    "License": "Commercial",
+    "License": "Proprietary",
     "Inception": "08-2015",
     "Category": "Essential - Professional",
     "Open Source": "No",

--- a/prismic.json
+++ b/prismic.json
@@ -2,7 +2,7 @@
     "Timestamp": "2018-07-28T16:44:21.225Z",
     "Name": "Prismic",
     "Version": "08-2018",
-    "License": "Commercial",
+    "License": "Proprietary",
     "Inception": "06-2013",
     "Category": "Essential - Professional",
     "Open Source": "No",


### PR DESCRIPTION
“Commercial” is an attribute, but not a license type. You could have a commercial CMS that is still distributed with an open source license, or a free CMS that has a proprietary license.

So I’ve changed all of the “Commercial” license values to “Proprietary”.