### PR TITLE
Changes GraphQL subscriptions to supported

### DIFF
--- a/enonic.json
+++ b/enonic.json
@@ -12,7 +12,7 @@
     "Commercial Support Available?": "Yes",
     "GraphQL API": "Yes",
     "GraphQL [Mutations]": "No",
-    "GraphQL [Subscriptions]": "No",
+    "GraphQL [Subscriptions]": "Yes",
     "REST API": "Pluggable",
     "REST [Create]": "Pluggable",
     "REST [Read]": "Pluggable",


### PR DESCRIPTION
Documented here:
https://developer.enonic.com/docs/headless-cms/stable/usage#sample_subscription

More doc coming, but it's fairly obvious when you use the API.